### PR TITLE
Treat version 0.x as unstable.

### DIFF
--- a/src/lib/Herrera/Version/Version.php
+++ b/src/lib/Herrera/Version/Version.php
@@ -124,7 +124,7 @@ class Version
      */
     public function isStable()
     {
-        return empty($this->preRelease);
+        return empty($this->preRelease) && $this->major !== 0;
     }
 
     /**

--- a/src/tests/lib/Herrera/Version/Tests/VersionTest.php
+++ b/src/tests/lib/Herrera/Version/Tests/VersionTest.php
@@ -110,6 +110,10 @@ class VersionTest extends TestCase
 
         $version = new Version();
 
+        $this->assertFalse($version->isStable());
+
+        $version = new Version(1);
+
         $this->assertTrue($version->isStable());
     }
 


### PR DESCRIPTION
Per section 4 of semver version [2.0.0](http://semver.org/spec/v2.0.0.html), "the public API should not be considered stable".  Therefore, I argue that isStable should return false for such a version.

This clause was also in semver version [1.0.0](http://semver.org/spec/v1.0.0.html) in section 6.
