### PR TITLE
Pre-release tags with hyphens are truncated

### DIFF
--- a/src/lib/Herrera/Version/Parser.php
+++ b/src/lib/Herrera/Version/Parser.php
@@ -73,7 +73,7 @@ class Parser
         }
 
         if (false !== strpos($version, '-')) {
-            list($version, $pre) = explode('-', $version);
+            list($version, $pre) = preg_split('/-/', $version, 1);
 
             $pre = explode('.', $pre);
         }


### PR DESCRIPTION
SemVer 2 says a "pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers" and identifiers "comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]".

if the version is '0.0.1-foo-bar.baz', the pre-release should be ['foo-bar', 'baz'].  Instead, it returns 'foo' - explode('-', $version) evaluates to ['0.0.1', 'foo', 'bar.baz'], and only the first two elements are assigned.

This change will return ['0.0.1', 'foo-bar.baz'], which can then be exploded on '.'
